### PR TITLE
Add support for :flag-**: emojis

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"unicode"
 )
 
@@ -21,12 +22,23 @@ func CodeMap() map[string]string {
 	return emojiCodeMap
 }
 
+// regular expression that matches :flag-[countrycode]:
+var flagRegexp = regexp.MustCompile(":flag-([a-z]{2}):")
+
 func emojize(x string) string {
 	str, ok := emojiCodeMap[x]
 	if ok {
 		return str + ReplacePadding
 	}
+	if match := flagRegexp.FindStringSubmatch(x); len(match) == 2 {
+		return regionalIndicator(match[1][0]) + regionalIndicator(match[1][1])
+	}
 	return x
+}
+
+// regionalIndicator maps a lowercase letter to a unicode regional indicator
+func regionalIndicator(i byte) string {
+	return string('\U0001F1E6' + rune(i) - 'a')
 }
 
 func replaseEmoji(input *bytes.Buffer) string {

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -9,10 +9,19 @@ import (
 const (
 	beerKey  = ":beer:"
 	beerText = " ビール!!!"
+	flag     = ":flag-us:"
 )
 
 var testFText = "test " + emojize(beerKey) + beerText
 var testText = emojize(beerKey) + beerText
+
+func TestFlag(t *testing.T) {
+	f := emojize(flag)
+	expected := "\U0001f1fA\U0001f1f8"
+	if f != expected {
+		t.Error("emojize ", f, "!=", expected)
+	}
+}
 
 func TestMultiColons(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
This small addition lets you compose flags using their ISO 3166-1 country code, such that `:flag-us:` renders as :us: