### PR TITLE
add support for emoji compilation in formatted arguments

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -87,67 +87,47 @@ func compile(x string) string {
 	return output.String()
 }
 
-func compileValues(a *[]interface{}) {
-	for i, x := range *a {
-		if str, ok := x.(string); ok {
-			(*a)[i] = compile(str)
-		}
-	}
-}
-
 // Print is fmt.Print which supports emoji
 func Print(a ...interface{}) (int, error) {
-	compileValues(&a)
-	return fmt.Print(a...)
+	return fmt.Print(compile(fmt.Sprint(a...)))
 }
 
 // Println is fmt.Println which supports emoji
 func Println(a ...interface{}) (int, error) {
-	compileValues(&a)
-	return fmt.Println(a...)
+	return fmt.Println(compile(fmt.Sprint(a...)))
 }
 
 // Printf is fmt.Printf which supports emoji
 func Printf(format string, a ...interface{}) (int, error) {
-	format = compile(format)
-	compileValues(&a)
-	return fmt.Printf(format, a...)
+	return fmt.Printf(compile(fmt.Sprintf(format, a...)))
 }
 
 // Fprint is fmt.Fprint which supports emoji
 func Fprint(w io.Writer, a ...interface{}) (int, error) {
-	compileValues(&a)
-	return fmt.Fprint(w, a...)
+	return fmt.Fprint(w, compile(fmt.Sprint(a...)))
 }
 
 // Fprintln is fmt.Fprintln which supports emoji
 func Fprintln(w io.Writer, a ...interface{}) (int, error) {
-	compileValues(&a)
-	return fmt.Fprintln(w, a...)
+	return fmt.Fprintln(w, compile(fmt.Sprint(a...)))
 }
 
 // Fprintf is fmt.Fprintf which supports emoji
 func Fprintf(w io.Writer, format string, a ...interface{}) (int, error) {
-	format = compile(format)
-	compileValues(&a)
-	return fmt.Fprintf(w, format, a...)
+	return fmt.Fprint(w, compile(fmt.Sprintf(format, a...)))
 }
 
 // Sprint is fmt.Sprint which supports emoji
 func Sprint(a ...interface{}) string {
-	compileValues(&a)
-	return fmt.Sprint(a...)
+	return compile(fmt.Sprint(a...))
 }
 
 // Sprintf is fmt.Sprintf which supports emoji
 func Sprintf(format string, a ...interface{}) string {
-	format = compile(format)
-	compileValues(&a)
-	return fmt.Sprintf(format, a...)
+	return compile(fmt.Sprintf(format, a...))
 }
 
 // Errorf is fmt.Errorf which supports emoji
 func Errorf(format string, a ...interface{}) error {
-	compileValues(&a)
-	return errors.New(Sprintf(format, a...))
+	return errors.New(compile(Sprintf(format, a...)))
 }


### PR DESCRIPTION
I have some structs that implement `String() string`, where `String()` could return something that contains an emoji. However, when doing something like:

```go
// type C implements String() string
Printf(":rocket: am I %s?\n", C("coloured :rocket:", RD, UL))
//  🚀  am I coloured :rocket:?
```

this happens because arguments to `Printf` or anything that takes `...interface{}` are compiled separately argument-by-argument ([example](https://github.com/kyokomi/emoji/blob/master/emoji.go#L100)), and only compiles emojis if it is a `string`:

```go
func compileValues(a *[]interface{}) {
	for i, x := range *a {
		if str, ok := x.(string); ok {
			(*a)[i] = compile(str)
		}
	}
}
```

there are 2 ways to support this:

* in `compileValues`, check for `String()` via type assertion and compile that
* call `Sprint` or the required variation of it *before* compiling, and make `compile` the last step before a print in every case

this PR implements the 2nd method, which I think is the cleanest and most consistent way to do it - if you prefer the other way, or have other ideas, I would be happy to implement it.

thanks!