### PR TITLE
Remove padding

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -12,11 +12,6 @@ import (
 
 //go:generate generateEmojiCodeMap -pkg emoji
 
-// Replace Padding character for emoji.
-const (
-	ReplacePadding = " "
-)
-
 // CodeMap gets the underlying map of emoji.
 func CodeMap() map[string]string {
 	return emojiCodeMap
@@ -52,7 +47,7 @@ var flagRegexp = regexp.MustCompile(":flag-([a-z]{2}):")
 func emojize(x string) string {
 	str, ok := emojiCodeMap[x]
 	if ok {
-		return str + ReplacePadding
+		return str
 	}
 	if match := flagRegexp.FindStringSubmatch(x); len(match) == 2 {
 		return regionalIndicator(match[1][0]) + regionalIndicator(match[1][1])

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -29,7 +29,7 @@ func TestFlag(t *testing.T) {
 
 func TestPlusOne(t *testing.T) {
 	f := emojize(plusOne)
-	expected := "\U0001f44d "
+	expected := "\U0001f44d"
 	if f != expected {
 		t.Error("emojize ", f, "!=", expected)
 	}


### PR DESCRIPTION
@kyokomi What is the purpose of `ReplacePadding`? If you have an emoji with a skin tone it currently renders like this:
<img width="85" alt="image" src="https://user-images.githubusercontent.com/1144020/79243700-f960ca00-7e43-11ea-8a9f-c7aafdb0ddda.png">

Removing this fixes the issue but I don't want to cause any unwanted side affects